### PR TITLE
Оновлення валідації вчительського імені

### DIFF
--- a/src/handlers/common/register.py
+++ b/src/handlers/common/register.py
@@ -168,7 +168,7 @@ class RegisterHandler(BaseHandler):
         teacher_name = message.text.strip()
 
         try:
-            await validate_teacher_name(teacher_name, db)
+            await validate_teacher_name(teacher_name)
             await state.update_data(teacher_name=teacher_name)
             await state.set_state(RegisterStates.finally_register)
             await self.finally_register(message, state, db)

--- a/src/handlers/developer/access/add.py
+++ b/src/handlers/developer/access/add.py
@@ -140,7 +140,7 @@ class AddAccessHandler(BaseHandler):
         user_id = int(user_id)
 
         try:
-            await validate_teacher_name(tn, db)
+            await validate_teacher_name(tn)
         except ValidationError as e:
             await message.answer(str(e))
             return False

--- a/src/handlers/developer/access/base_blocker.py
+++ b/src/handlers/developer/access/base_blocker.py
@@ -162,7 +162,7 @@ class BaseBlockerAccessHandler(BaseHandler, ABC):
         teacher_name = message.text
 
         try:
-            await validate_teacher_name(teacher_name, db)
+            await validate_teacher_name(teacher_name)
         except ValidationError as e:
             await message.answer(str(e))
             return

--- a/src/handlers/developer/access/status.py
+++ b/src/handlers/developer/access/status.py
@@ -119,7 +119,7 @@ class StatusAccessHandler(BaseHandler):
         teacher_name = message.text
 
         try:
-            await validate_teacher_name(teacher_name, db)
+            await validate_teacher_name(teacher_name)
         except ValidationError as e:
             await message.answer(str(e))
             return

--- a/src/validators/teacher_name.py
+++ b/src/validators/teacher_name.py
@@ -17,7 +17,7 @@ TEACHER_NAME_PATTERN:
 """
 
 
-async def validate_teacher_name(teacher_name: str, db: DBConnector) -> bool:
+async def validate_teacher_name(teacher_name: str) -> bool:
     """
     Валідує ім'я вчителя, наприклад (Іванов Іван Іванович)
 
@@ -42,12 +42,5 @@ async def validate_teacher_name(teacher_name: str, db: DBConnector) -> bool:
 
     if not isinstance(teacher_name, str) or not match:
         raise ValidationError("Використовуйте формат \"Прізвище ім'я по-батькові\"")
-
-    if not await db.register.teacher_is_exists(teacher_name):
-        raise ValidationError(
-            "🚫 Такого ПІП немає в нашому списку вчителів. "
-            "Можливо, ви ввели з помилкою або ще не додані до бази.\n"
-            "Спробуйте ще раз або зверніться до @omyzsh 👨‍💻"
-        )
 
     return True


### PR DESCRIPTION
- У `validate_teacher_name` прибрано виклик до БД, тепер діє перевірка тільки по `regex`
- Поправлено виклики функції у хендерах: видалено аргумент `db`